### PR TITLE
修复点击SingleChildScrollView的crash问题；部分搜索条目也有同样的问题

### DIFF
--- a/lib/storage/dao/widget_dao.dart
+++ b/lib/storage/dao/widget_dao.dart
@@ -46,6 +46,11 @@ class WidgetDao {
   }
 
   Future<List<Map<String, dynamic>>> queryByIds(List<int> ids) async {
+
+    if (ids.length == 0) {
+      return [];
+    }
+
     final db = await storage.db;
 
     var sql = "SELECT * "


### PR DESCRIPTION
在stles tab下点击SingleChildScrollView时遇到了crash，搜索场景也有遇到。
debug了一下，发现是调用FMDatabase的时候，查询的params个数为0导致的,具体是crash到了839行，这里在上层查询的时候简单保护下
![image](https://user-images.githubusercontent.com/4124906/80858878-1cd2a400-8c8f-11ea-8747-6c87935d0950.png)
