### PR TITLE
Update widgets_map.dart

### DIFF
--- a/packages/widgets/lib/widgets_map.dart
+++ b/packages/widgets/lib/widgets_map.dart
@@ -1165,8 +1165,8 @@ class WidgetsMap {
         return [
           CustomListView(),
           HorizontalListView(),
-          SeparatedListView(),
           BuilderListView(),
+          SeparatedListView(),
         ];
       case "GridView":
         return [


### PR DESCRIPTION
勘误：BuilderListView和SeparatedListView顺序相反，看是否含橙色分割线即可发现；