### PR TITLE
fix: broken star history chart

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -97,7 +97,7 @@ Build web:
 
 #### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=toly1994328/FlutterUnit&type=Date)](https://star-history.com/#toly1994328/FlutterUnit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=toly1994328/FlutterUnit&type=Date)](https://star-history.dera.page/#toly1994328/FlutterUnit&Date)
 
 ### 一、组件的展示页面
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Build web:
 
 #### Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=toly1994328/FlutterUnit&type=Date)](https://star-history.com/#toly1994328/FlutterUnit&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=toly1994328/FlutterUnit&type=Date)](https://star-history.dera.page/#toly1994328/FlutterUnit&Date)
 
 ### 一、组件的展示页面
 


### PR DESCRIPTION
The star history chart is currently broken because of GitHub stargazer API restrictions, so it no longer renders in the README. This change points it at a working provider using the same domain for both the chart and the link. Updated in README.md and README-EN.md.